### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/common/channel/websocket/remote.go
+++ b/common/channel/websocket/remote.go
@@ -16,7 +16,7 @@ var (
 	}
 )
 
-// handleWebsocket connection. Update to
+// WebsocketInvoke connection. Update to
 func WebsocketInvoke(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" {
 		http.Error(w, "Method not allowed", 405)

--- a/common/helper/bytes.go
+++ b/common/helper/bytes.go
@@ -17,7 +17,7 @@ func PKCS7Pad(buf *bytes.Buffer, blen int) {
 	}
 }
 
-// Returns slice of the original data without padding.
+// PKCS7Unpad returns slice of the original data without padding.
 func PKCS7Unpad(in []byte) []byte {
 	if len(in) == 0 {
 		return nil

--- a/common/logger/color_console_windows.go
+++ b/common/logger/color_console_windows.go
@@ -73,7 +73,7 @@ func isCygwinPipeName(name string) bool {
 	return true
 }
 
-// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// IsCygwinTerminal return true if the file descriptor is a cygwin or msys2
 // terminal.
 func IsCygwinTerminal(fd uintptr) bool {
 	if procGetFileInformationByHandleEx == nil {

--- a/common/socks/socks.go
+++ b/common/socks/socks.go
@@ -283,7 +283,7 @@ func (ln *SocksListener) AcceptSocks() (*SocksConn, error) {
 	return conn, nil
 }
 
-// Returns "socks5", suitable to be included in a call to Cmethod.
+// Version returns "socks5", suitable to be included in a call to Cmethod.
 func (ln *SocksListener) Version() string {
 	return "socks5"
 }


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._